### PR TITLE
Improve try-it demo UX: samples and result storytelling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6378,6 +6378,119 @@ section, div {
     text-align: center;
 }
 
+.tryit-generate-hint {
+    margin-top: 0.65rem;
+    text-align: center;
+    color: #64748b;
+    font-size: 0.85rem;
+}
+
+.tryit-sample-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.tryit-sample-btn {
+    margin-top: 0.5rem;
+    padding: 0.45rem 0.85rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+    color: #334155;
+    font: inherit;
+    font-size: 0.88rem;
+    cursor: pointer;
+}
+
+.tryit-sample-row .tryit-sample-btn {
+    margin-top: 0;
+    flex: 1 1 auto;
+}
+
+.tryit-sample-btn-pair {
+    border-color: #166534;
+    color: #166534;
+    background: #f0fdf4;
+}
+
+.tryit-sample-btn:hover {
+    background: #f8fafc;
+    border-color: #94a3b8;
+}
+
+.tryit-what-happened {
+    margin-bottom: 1.25rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid #bbf7d0;
+}
+
+.tryit-what-happened-title {
+    margin: 0 0 0.85rem;
+    color: #166534;
+    font-size: 0.95rem;
+    font-weight: 800;
+    text-align: center;
+}
+
+.tryit-what-steps {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.tryit-what-step {
+    margin-bottom: 0.85rem;
+}
+
+.tryit-what-step:last-child {
+    margin-bottom: 0;
+}
+
+.tryit-step-label {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: #15803d;
+    font-size: 0.82rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.tryit-step-text {
+    margin: 0;
+    color: #14532d;
+    font-size: 0.92rem;
+    line-height: 1.5;
+}
+
+.tryit-match-reasons {
+    margin: 0.45rem 0 0;
+    padding-left: 1.15rem;
+    color: #166534;
+    font-size: 0.88rem;
+    line-height: 1.45;
+}
+
+.tryit-approach-help {
+    margin: 0 0 0.5rem;
+    color: #64748b;
+    font-size: 0.85rem;
+    text-align: center;
+}
+
+.tryit-result-context {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 8px;
+    background: #fff7ed;
+    border: 1px solid #fed7aa;
+    color: #9a3412;
+    font-size: 0.92rem;
+    line-height: 1.45;
+}
+
 .tryit-char-count {
     margin-top: 0.35rem;
     font-size: 0.85rem;

--- a/js/try-it-demo.js
+++ b/js/try-it-demo.js
@@ -11,6 +11,41 @@
   ];
   var LOADER_INTERVAL_MS = 4000;
 
+  var SAMPLE_SCENARIOS = [
+    {
+      label: 'Data engineer',
+      post:
+        "We're hiring a senior data engineer to build scalable data pipelines, improve analytics reliability, and help our platform grow. Experience with Python, SQL, and cloud data tooling is a plus.",
+      bio:
+        "Data engineer with 5 years building ETL pipelines in Python and AWS. I've optimized production analytics workflows and enjoy connecting data systems to business outcomes."
+    },
+    {
+      label: 'Product manager',
+      post:
+        "Looking for a product manager to own our B2B SaaS roadmap, run discovery with customers, and ship features that move activation and retention. You'll partner closely with eng and design.",
+      bio:
+        "PM with 6 years in B2B SaaS. I've launched onboarding flows that lifted activation 30% and run weekly customer interviews to prioritize the roadmap."
+    },
+    {
+      label: 'Frontend engineer',
+      post:
+        "We're growing our frontend team and hiring a React engineer to improve performance, design systems, and accessibility across our customer dashboard. Remote-friendly.",
+      bio:
+        "Frontend engineer focused on React, TypeScript, and accessible UI. I've led design-system migrations and cut dashboard load times with smarter data fetching."
+    },
+    {
+      label: 'ML engineer',
+      post:
+        "Hiring an ML engineer to productionize models, improve inference latency, and build evaluation pipelines for our recommendation stack. PyTorch or TensorFlow experience welcome.",
+      bio:
+        "ML engineer shipping models to production for 4 years. I care about evals, monitoring, and the gap between notebook experiments and reliable services."
+    }
+  ];
+
+  var samplePostIndex = 0;
+  var sampleBioIndex = 0;
+  var samplePairIndex = 0;
+
   var STORAGE = {
     attempts: 'juniorTryItAttempts',
     draft: 'juniorTryItDraft',
@@ -26,6 +61,7 @@
     comment: null,
     verified: false,
     fallback: false,
+    shouldComment: null,
     status: 'idle',
     isRegenerate: false
   };
@@ -190,7 +226,7 @@
     var bioLen = state.userBio.length;
 
     if (postCount) {
-      postCount.textContent = postLen + ' / 3000 (min 20)';
+      postCount.textContent = postLen + ' / 3000 · min 20 characters';
       postCount.classList.toggle('tryit-count-warn', postLen > 0 && postLen < 20);
     }
     if (bioCount) bioCount.textContent = bioLen + ' / 2000';
@@ -222,40 +258,153 @@
     updateSignupLinks();
   }
 
+  function buildWhatHappenedSteps(data, isSampleOnly) {
+    var qual = data.qualification || {};
+    var angle = qual.suggested_angle || data.suggested_angle || '';
+    var score = typeof qual.priority_score === 'number' ? qual.priority_score : null;
+    var reasons = Array.isArray(qual.match_reasons) ? qual.match_reasons : [];
+
+    if (isSampleOnly) {
+      if (qual.should_comment === false) {
+        return {
+          validate:
+            'We read your LinkedIn post and your background. This demo only personalizes hiring posts, and this one did not qualify.',
+          approach: 'Junior did not pick a personalized approach for this post.',
+          comment:
+            'What you see below is a generic example, not a comment built from your post and profile. Try one of the sample hiring posts above.'
+        };
+      }
+      return {
+        validate: 'We read your post and profile, but could not personalize this run.',
+        approach: 'No approach was applied.',
+        comment:
+          'What you see below is a generic sample, not a comment tailored to your inputs.'
+      };
+    }
+
+    var validateText =
+      'We read the LinkedIn post you pasted and matched it against your background.';
+    if (score != null) {
+      validateText += ' The fit scored ' + score + ' out of 100.';
+    }
+    if (reasons.length) {
+      validateText += ' Here is why this post is worth a comment:';
+    } else {
+      validateText += ' This looks like a good post to engage with.';
+    }
+
+    var approachText = angle
+      ? 'Based on that match, Junior chose this approach: “' + angle + '”.'
+      : 'Junior wrote straight from your post and profile. No separate approach was returned this time.';
+
+    var commentText = data.verified
+      ? 'Junior drafted the comment below using that approach and checked it before showing it to you.'
+      : 'Junior drafted the comment below using that approach.';
+
+    return { validate: validateText, approach: approachText, comment: commentText };
+  }
+
   function showResult(data) {
     state.comment = data.comment || '';
     state.fallback = Boolean(data.fallback);
     state.verified = Boolean(data.verified);
+    state.shouldComment =
+      data.qualification && typeof data.qualification.should_comment === 'boolean'
+        ? data.qualification.should_comment
+        : null;
     state.suggestedAngle =
       (data.qualification && data.qualification.suggested_angle) ||
       data.suggested_angle ||
-      state.suggestedAngle ||
       '';
+
+    var isSampleOnly = state.fallback || state.shouldComment === false;
+    var hasAngle = Boolean(state.suggestedAngle.trim());
+    var qual = data.qualification || {};
+    var matchReasons = Array.isArray(qual.match_reasons) ? qual.match_reasons : [];
 
     var result = $('tryit-demo-result');
     var commentBox = $('tryit-demo-comment');
+    var commentLabel = $('tryit-comment-label');
     var angleInput = $('tryit-suggested-angle');
     var approachBlock = $('tryit-approach-block');
+    var approachHelp = $('tryit-approach-help');
+    var regenerateBtn = $('tryit-regenerate-button');
     var fallbackNote = $('tryit-fallback-note');
     var verifiedBadge = $('tryit-verified-badge');
+    var resultContext = $('tryit-result-context');
+    var whatHappened = $('tryit-what-happened');
+    var stepValidate = $('tryit-step-validate-text');
+    var stepApproach = $('tryit-step-approach-text');
+    var stepComment = $('tryit-step-comment-text');
+    var matchReasonsEl = $('tryit-match-reasons');
+    var copyButton = $('tryit-copy-comment');
+    var successCta = $('tryit-success-cta');
+
+    var steps = buildWhatHappenedSteps(data, isSampleOnly);
+
+    if (whatHappened) whatHappened.hidden = false;
+    if (stepValidate) stepValidate.textContent = steps.validate;
+    if (stepApproach) stepApproach.textContent = steps.approach;
+    if (stepComment) stepComment.textContent = steps.comment;
+
+    if (matchReasonsEl) {
+      matchReasonsEl.innerHTML = '';
+      if (!isSampleOnly && matchReasons.length) {
+        matchReasons.forEach(function (reason) {
+          var li = document.createElement('li');
+          li.textContent = reason;
+          matchReasonsEl.appendChild(li);
+        });
+        matchReasonsEl.hidden = false;
+      } else {
+        matchReasonsEl.hidden = true;
+      }
+    }
 
     if (commentBox) commentBox.textContent = state.comment;
+    if (commentLabel) {
+      commentLabel.textContent = isSampleOnly ? 'Example comment' : 'Your comment';
+    }
     if (angleInput) angleInput.value = state.suggestedAngle;
-    if (approachBlock) approachBlock.hidden = false;
+    if (approachBlock) approachBlock.hidden = isSampleOnly;
+    if (approachHelp) {
+      approachHelp.textContent = hasAngle
+        ? 'Want a different angle? Edit the approach above and hit regenerate.'
+        : 'Add how you would like to connect to this post, then regenerate.';
+    }
+    if (regenerateBtn) regenerateBtn.hidden = isSampleOnly;
 
-    if (fallbackNote) fallbackNote.hidden = !state.fallback;
-    if (verifiedBadge) verifiedBadge.hidden = !(state.verified && !state.fallback);
+    if (resultContext) {
+      if (isSampleOnly) {
+        resultContext.hidden = false;
+        resultContext.textContent =
+          'Try a matched sample hiring post above, then generate again to see real personalization.';
+      } else {
+        resultContext.hidden = true;
+        resultContext.textContent = '';
+      }
+    }
+
+    if (fallbackNote) fallbackNote.hidden = !isSampleOnly;
+    if (verifiedBadge) verifiedBadge.hidden = !(state.verified && !isSampleOnly);
+    if (copyButton) copyButton.hidden = isSampleOnly;
+    if (successCta) successCta.hidden = isSampleOnly;
 
     if (result) {
       result.hidden = false;
       result.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
 
-    persistSignupContext();
+    if (!isSampleOnly) {
+      persistSignupContext();
+    }
     updateSignupLinks();
 
-    if (state.fallback) {
-      track('tryit_fallback_shown', { source: 'try-it-page' });
+    if (isSampleOnly) {
+      track('tryit_fallback_shown', {
+        source: 'try-it-page',
+        should_comment: state.shouldComment
+      });
     } else {
       track('tryit_result_shown', { source: 'try-it-page', verified: state.verified });
     }
@@ -288,6 +437,9 @@
 
     readFormIntoState();
     clearError();
+
+    maybeCycleSamplesBeforeGenerate();
+    readFormIntoState();
 
     if (isRegenerate) {
       if (!validateRegenerate()) return;
@@ -324,10 +476,21 @@
       var data = await window.DemoCommentClient.generateDemoComment(payload, abortController.signal);
       clearTimeout(timeoutId);
 
-      setAttempts(getAttempts() + 1);
-      updateAttemptsUI();
+      var isSampleOnly =
+        Boolean(data.fallback) ||
+        (data.qualification && data.qualification.should_comment === false);
+
+      if (!isSampleOnly) {
+        setAttempts(getAttempts() + 1);
+        updateAttemptsUI();
+      }
+
       showResult(data);
-      state.status = 'success';
+      state.status = isSampleOnly ? 'fallback' : 'success';
+
+      if (isSampleOnly) {
+        setError('This demo works on hiring posts. Load the sample post or paste a job listing.');
+      }
 
       if (isLockedOut()) {
         showLockout("You've seen how it works. Create your account to generate more comments.");
@@ -394,11 +557,98 @@
     }
   }
 
+  function nextSampleIndex(current, length) {
+    return (current + 1) % length;
+  }
+
+  function updateSampleButtonLabels() {
+    var n = SAMPLE_SCENARIOS.length;
+    var postBtn = $('tryit-load-sample-post');
+    var bioBtn = $('tryit-load-sample-bio');
+    var pairBtn = $('tryit-load-sample-pair');
+    var nextPost = nextSampleIndex(samplePostIndex, n);
+    var nextBio = nextSampleIndex(sampleBioIndex, n);
+    var nextPair = nextSampleIndex(samplePairIndex, n);
+
+    if (postBtn) {
+      postBtn.textContent =
+        'Try sample post · ' + SAMPLE_SCENARIOS[nextPost].label + ' · ' + (nextPost + 1) + ' of ' + n;
+    }
+    if (bioBtn) {
+      bioBtn.textContent =
+        'Try sample bio · ' + SAMPLE_SCENARIOS[nextBio].label + ' · ' + (nextBio + 1) + ' of ' + n;
+    }
+    if (pairBtn) {
+      pairBtn.textContent =
+        'Try matched pair · ' + SAMPLE_SCENARIOS[nextPair].label + ' · ' + (nextPair + 1) + ' of ' + n;
+    }
+  }
+
+  function applySamplePost(advance) {
+    if (advance) samplePostIndex = nextSampleIndex(samplePostIndex, SAMPLE_SCENARIOS.length);
+    state.postText = SAMPLE_SCENARIOS[samplePostIndex].post;
+    syncFormFromState();
+    saveDraft();
+    updateSampleButtonLabels();
+    clearError();
+  }
+
+  function applySampleBio(advance) {
+    if (advance) sampleBioIndex = nextSampleIndex(sampleBioIndex, SAMPLE_SCENARIOS.length);
+    state.userBio = SAMPLE_SCENARIOS[sampleBioIndex].bio;
+    syncFormFromState();
+    saveDraft();
+    updateSampleButtonLabels();
+    clearError();
+  }
+
+  function applySamplePair(advance) {
+    if (advance) samplePairIndex = nextSampleIndex(samplePairIndex, SAMPLE_SCENARIOS.length);
+    var scenario = SAMPLE_SCENARIOS[samplePairIndex];
+    state.postText = scenario.post;
+    state.userBio = scenario.bio;
+    samplePostIndex = samplePairIndex;
+    sampleBioIndex = samplePairIndex;
+    syncFormFromState();
+    saveDraft();
+    updateSampleButtonLabels();
+    clearError();
+  }
+
+  /** On Generate: cycle samples when fields are empty so users can quick-test without typing. */
+  function maybeCycleSamplesBeforeGenerate() {
+    var postEmpty = state.postText.trim().length < 20;
+    var bioEmpty = state.userBio.trim().length === 0;
+
+    if (postEmpty && bioEmpty) {
+      applySamplePair(true);
+      return true;
+    }
+    if (postEmpty) applySamplePost(true);
+    if (bioEmpty) applySampleBio(true);
+    return postEmpty || bioEmpty;
+  }
+
+  function loadSamplePost() {
+    applySamplePost(true);
+  }
+
+  function loadSampleBio() {
+    applySampleBio(true);
+  }
+
+  function loadSamplePair() {
+    applySamplePair(true);
+    var formSection = $('try-it');
+    if (formSection) formSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   function init() {
     if (!window.DemoCommentClient) return;
 
     loadDraft();
     syncFormFromState();
+    updateSampleButtonLabels();
     updateAttemptsUI();
     updateSignupLinks();
 
@@ -412,6 +662,13 @@
     var toneInput = $('tryit-tone');
     var regenerateBtn = $('tryit-regenerate-button');
     var copyButton = $('tryit-copy-comment');
+    var samplePostBtn = $('tryit-load-sample-post');
+    var sampleBioBtn = $('tryit-load-sample-bio');
+    var samplePairBtn = $('tryit-load-sample-pair');
+
+    if (samplePostBtn) samplePostBtn.addEventListener('click', loadSamplePost);
+    if (sampleBioBtn) sampleBioBtn.addEventListener('click', loadSampleBio);
+    if (samplePairBtn) samplePairBtn.addEventListener('click', loadSamplePair);
 
     if (form) {
       form.addEventListener('submit', function (event) {

--- a/try-it.html
+++ b/try-it.html
@@ -47,24 +47,29 @@
     <main class="reddit-lp" style="padding-top: 120px;">
         <section class="rl-hero">
             <h1>Try Junior in your browser</h1>
-            <p>Paste a post, add your bio, pick a tone, and generate a personalized comment.</p>
-            <p class="rl-hero-trust">You get 3 free tries. Then we will ask you to sign up.</p>
+            <p>Paste a <strong>hiring post</strong>, add your bio, pick a tone, and see a personalized comment.</p>
+            <p class="rl-hero-trust">Best on job posts. You get 3 free tries — then we ask you to sign up.</p>
         </section>
 
         <section class="rl-section rl-interactive-demo" id="try-it">
             <h2 class="rl-h2">Generate your comment</h2>
             <form class="rl-demo-form" id="tryit-demo-form">
                 <div class="rl-demo-field">
-                    <label for="tryit-post">LinkedIn post</label>
-                    <textarea id="tryit-post" class="rl-demo-textarea" rows="7" maxlength="3000" required placeholder="Paste the LinkedIn post you want to comment on..."></textarea>
-                    <p class="rl-demo-help tryit-char-count" id="tryit-post-count" aria-live="polite">0 / 3000 (min 20)</p>
+                    <label for="tryit-post">LinkedIn hiring post</label>
+                    <textarea id="tryit-post" class="rl-demo-textarea" rows="7" maxlength="3000" required placeholder="Paste a hiring post, e.g. We're hiring a data engineer… The demo personalizes job posts best."></textarea>
+                    <p class="rl-demo-help tryit-char-count" id="tryit-post-count" aria-live="polite">0 / 3000 · min 20 characters</p>
+                    <div class="tryit-sample-row">
+                        <button type="button" class="tryit-sample-btn" id="tryit-load-sample-post">Try sample post</button>
+                        <button type="button" class="tryit-sample-btn tryit-sample-btn-pair" id="tryit-load-sample-pair">Try matched pair</button>
+                    </div>
                 </div>
 
                 <div class="rl-demo-field">
-                    <label for="tryit-bio">About you (2–3 sentences)</label>
+                    <label for="tryit-bio">About you — 2 to 3 sentences</label>
                     <textarea id="tryit-bio" class="rl-demo-textarea" rows="6" maxlength="2000" placeholder="e.g. I build data pipelines in Python and SQL, with 5 years in analytics engineering..."></textarea>
                     <p class="rl-demo-help tryit-char-count" id="tryit-bio-count" aria-live="polite">0 / 2000</p>
                     <p class="rl-demo-help tryit-bio-warn" id="tryit-bio-warn">Adding your background strongly improves personalization.</p>
+                    <button type="button" class="tryit-sample-btn" id="tryit-load-sample-bio">Try sample bio</button>
                 </div>
 
                 <div class="rl-demo-field">
@@ -86,27 +91,50 @@
                 <p class="tryit-loader" id="tryit-loader" hidden aria-live="polite">Understanding the post…</p>
 
                 <button type="submit" class="rl-button rl-generate-btn" id="tryit-demo-button">Generate comment</button>
+                <p class="rl-demo-help tryit-generate-hint">Tip: click sample buttons to cycle scenarios, or hit Generate with empty fields to auto-load the next matched pair.</p>
                 <p class="rl-demo-help" id="tryit-attempts-help" aria-live="polite"></p>
                 <p class="rl-demo-error" id="tryit-demo-error" hidden></p>
             </form>
         </section>
 
         <section class="rl-section rl-result tryit-result" id="tryit-demo-result" hidden>
+            <div class="tryit-what-happened" id="tryit-what-happened" hidden>
+                <p class="tryit-what-happened-title">How Junior wrote this</p>
+                <ol class="tryit-what-steps">
+                    <li class="tryit-what-step" id="tryit-step-validate">
+                        <span class="tryit-step-label">1. Read &amp; validate</span>
+                        <p class="tryit-step-text" id="tryit-step-validate-text"></p>
+                        <ul class="tryit-match-reasons" id="tryit-match-reasons" hidden></ul>
+                    </li>
+                    <li class="tryit-what-step" id="tryit-step-approach">
+                        <span class="tryit-step-label">2. Pick an approach</span>
+                        <p class="tryit-step-text" id="tryit-step-approach-text"></p>
+                    </li>
+                    <li class="tryit-what-step" id="tryit-step-comment">
+                        <span class="tryit-step-label">3. Write the comment</span>
+                        <p class="tryit-step-text" id="tryit-step-comment-text"></p>
+                    </li>
+                </ol>
+            </div>
+
             <div class="tryit-approach-block" id="tryit-approach-block" hidden>
-                <label for="tryit-suggested-angle" class="rl-result-label">Suggested approach</label>
+                <label for="tryit-suggested-angle" class="rl-result-label">Edit the approach</label>
+                <p class="tryit-approach-help" id="tryit-approach-help">Tweak how you want to connect to this post, then regenerate.</p>
                 <textarea id="tryit-suggested-angle" class="rl-demo-textarea tryit-approach-field" rows="3" maxlength="500" placeholder="How Junior would connect your experience to this post…"></textarea>
                 <button type="button" class="rl-button tryit-regenerate-btn" id="tryit-regenerate-button">Regenerate with this approach</button>
             </div>
 
+            <p class="tryit-result-context" id="tryit-result-context" hidden></p>
+
             <div class="tryit-comment-header">
-                <p class="rl-result-label">Your comment</p>
+                <p class="rl-result-label" id="tryit-comment-label">Your comment</p>
                 <span class="tryit-verified-badge" id="tryit-verified-badge" hidden>Quality-checked</span>
             </div>
 
             <div class="rl-result-comment" id="tryit-demo-comment"></div>
 
             <p class="tryit-fallback-note" id="tryit-fallback-note" hidden>
-                We used a sample comment — sign up for personalized results.
+                This is a generic sample — not based on your post. Paste a hiring post and try again, or sign up for comments on any post type.
             </p>
 
             <div class="rl-share-actions rl-share-actions-single">


### PR DESCRIPTION
## Summary
- Add four cycling sample scenarios with separate post, bio, and matched-pair buttons; empty Generate auto-loads the next pair.
- Show a three-step **How Junior wrote this** panel from API `qualification` data: validate with match reasons, approach, then comment.
- Handle fallback runs clearly when posts do not qualify; do not burn free tries on sample-only responses.

## Test plan
- [ ] Load try-it locally, cycle sample buttons and confirm labels advance
- [ ] Generate with empty fields — matched pair loads and runs
- [ ] Generate with a non-hiring post — fallback copy and no attempt consumed
- [ ] Generate with a hiring sample — three-step panel, approach field, and comment shown
- [ ] Regenerate with edited approach still works


Made with [Cursor](https://cursor.com)