### PR TITLE
Simplify try-it to one sample button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6378,6 +6378,11 @@ section, div {
     text-align: center;
 }
 
+.rl-interactive-demo[aria-disabled="true"] {
+    opacity: 0.72;
+    pointer-events: none;
+}
+
 .tryit-generate-hint {
     margin-top: 0.65rem;
     text-align: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -6385,39 +6385,25 @@ section, div {
     font-size: 0.85rem;
 }
 
-.tryit-sample-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-}
-
 .tryit-sample-btn {
-    margin-top: 0.5rem;
-    padding: 0.45rem 0.85rem;
-    border: 1px solid #cbd5e1;
+    display: block;
+    width: 100%;
+    margin: 0 0 1rem;
+    padding: 0.55rem 0.85rem;
+    border: 1px solid #166534;
     border-radius: 8px;
-    background: #fff;
-    color: #334155;
-    font: inherit;
-    font-size: 0.88rem;
-    cursor: pointer;
-}
-
-.tryit-sample-row .tryit-sample-btn {
-    margin-top: 0;
-    flex: 1 1 auto;
-}
-
-.tryit-sample-btn-pair {
-    border-color: #166534;
-    color: #166534;
     background: #f0fdf4;
+    color: #166534;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: center;
 }
 
 .tryit-sample-btn:hover {
-    background: #f8fafc;
-    border-color: #94a3b8;
+    background: #dcfce7;
+    border-color: #15803d;
 }
 
 .tryit-what-happened {

--- a/js/try-it-demo.js
+++ b/js/try-it-demo.js
@@ -42,9 +42,7 @@
     }
   ];
 
-  var samplePostIndex = 0;
-  var sampleBioIndex = 0;
-  var samplePairIndex = 0;
+  var sampleIndex = 0;
 
   var STORAGE = {
     attempts: 'juniorTryItAttempts',
@@ -489,7 +487,7 @@
       state.status = isSampleOnly ? 'fallback' : 'success';
 
       if (isSampleOnly) {
-        setError('This demo works on hiring posts. Load the sample post or paste a job listing.');
+        setError('This demo works on hiring posts. Try a sample or paste a job listing.');
       }
 
       if (isLockedOut()) {
@@ -561,86 +559,47 @@
     return (current + 1) % length;
   }
 
-  function updateSampleButtonLabels() {
+  function updateSampleButtonLabel() {
+    var btn = $('tryit-load-sample');
+    if (!btn) return;
     var n = SAMPLE_SCENARIOS.length;
-    var postBtn = $('tryit-load-sample-post');
-    var bioBtn = $('tryit-load-sample-bio');
-    var pairBtn = $('tryit-load-sample-pair');
-    var nextPost = nextSampleIndex(samplePostIndex, n);
-    var nextBio = nextSampleIndex(sampleBioIndex, n);
-    var nextPair = nextSampleIndex(samplePairIndex, n);
-
-    if (postBtn) {
-      postBtn.textContent =
-        'Try sample post · ' + SAMPLE_SCENARIOS[nextPost].label + ' · ' + (nextPost + 1) + ' of ' + n;
-    }
-    if (bioBtn) {
-      bioBtn.textContent =
-        'Try sample bio · ' + SAMPLE_SCENARIOS[nextBio].label + ' · ' + (nextBio + 1) + ' of ' + n;
-    }
-    if (pairBtn) {
-      pairBtn.textContent =
-        'Try matched pair · ' + SAMPLE_SCENARIOS[nextPair].label + ' · ' + (nextPair + 1) + ' of ' + n;
-    }
+    var next = nextSampleIndex(sampleIndex, n);
+    btn.textContent =
+      'Try a sample · ' + SAMPLE_SCENARIOS[next].label + ' · ' + (next + 1) + ' of ' + n;
   }
 
-  function applySamplePost(advance) {
-    if (advance) samplePostIndex = nextSampleIndex(samplePostIndex, SAMPLE_SCENARIOS.length);
-    state.postText = SAMPLE_SCENARIOS[samplePostIndex].post;
-    syncFormFromState();
-    saveDraft();
-    updateSampleButtonLabels();
-    clearError();
-  }
-
-  function applySampleBio(advance) {
-    if (advance) sampleBioIndex = nextSampleIndex(sampleBioIndex, SAMPLE_SCENARIOS.length);
-    state.userBio = SAMPLE_SCENARIOS[sampleBioIndex].bio;
-    syncFormFromState();
-    saveDraft();
-    updateSampleButtonLabels();
-    clearError();
-  }
-
-  function applySamplePair(advance) {
-    if (advance) samplePairIndex = nextSampleIndex(samplePairIndex, SAMPLE_SCENARIOS.length);
-    var scenario = SAMPLE_SCENARIOS[samplePairIndex];
+  function applySample(advance) {
+    if (advance) sampleIndex = nextSampleIndex(sampleIndex, SAMPLE_SCENARIOS.length);
+    var scenario = SAMPLE_SCENARIOS[sampleIndex];
     state.postText = scenario.post;
     state.userBio = scenario.bio;
-    samplePostIndex = samplePairIndex;
-    sampleBioIndex = samplePairIndex;
     syncFormFromState();
     saveDraft();
-    updateSampleButtonLabels();
+    updateSampleButtonLabel();
     clearError();
   }
 
-  /** On Generate: cycle samples when fields are empty so users can quick-test without typing. */
   function maybeCycleSamplesBeforeGenerate() {
     var postEmpty = state.postText.trim().length < 20;
     var bioEmpty = state.userBio.trim().length === 0;
 
+    if (!postEmpty && !bioEmpty) return false;
+
     if (postEmpty && bioEmpty) {
-      applySamplePair(true);
+      applySample(true);
       return true;
     }
-    if (postEmpty) applySamplePost(true);
-    if (bioEmpty) applySampleBio(true);
-    return postEmpty || bioEmpty;
+
+    var scenario = SAMPLE_SCENARIOS[sampleIndex];
+    if (postEmpty) state.postText = scenario.post;
+    if (bioEmpty) state.userBio = scenario.bio;
+    syncFormFromState();
+    saveDraft();
+    return true;
   }
 
-  function loadSamplePost() {
-    applySamplePost(true);
-  }
-
-  function loadSampleBio() {
-    applySampleBio(true);
-  }
-
-  function loadSamplePair() {
-    applySamplePair(true);
-    var formSection = $('try-it');
-    if (formSection) formSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  function loadSample() {
+    applySample(true);
   }
 
   function init() {
@@ -648,7 +607,7 @@
 
     loadDraft();
     syncFormFromState();
-    updateSampleButtonLabels();
+    updateSampleButtonLabel();
     updateAttemptsUI();
     updateSignupLinks();
 
@@ -662,13 +621,9 @@
     var toneInput = $('tryit-tone');
     var regenerateBtn = $('tryit-regenerate-button');
     var copyButton = $('tryit-copy-comment');
-    var samplePostBtn = $('tryit-load-sample-post');
-    var sampleBioBtn = $('tryit-load-sample-bio');
-    var samplePairBtn = $('tryit-load-sample-pair');
+    var sampleBtn = $('tryit-load-sample');
 
-    if (samplePostBtn) samplePostBtn.addEventListener('click', loadSamplePost);
-    if (sampleBioBtn) sampleBioBtn.addEventListener('click', loadSampleBio);
-    if (samplePairBtn) samplePairBtn.addEventListener('click', loadSamplePair);
+    if (sampleBtn) sampleBtn.addEventListener('click', loadSample);
 
     if (form) {
       form.addEventListener('submit', function (event) {

--- a/js/try-it-demo.js
+++ b/js/try-it-demo.js
@@ -48,7 +48,8 @@
     attempts: 'juniorTryItAttempts',
     draft: 'juniorTryItDraft',
     userBio: 'juniorTryItUserBio',
-    suggestedAngle: 'juniorTryItSuggestedAngle'
+    suggestedAngle: 'juniorTryItSuggestedAngle',
+    lastResult: 'juniorTryItLastResult'
   };
 
   var state = {
@@ -240,20 +241,77 @@
     }
   }
 
-  function showLockout(message) {
+  function setFormDisabled(disabled) {
+    var formSection = $('try-it');
+    var generateBtn = $('tryit-demo-button');
+    var regenerateBtn = $('tryit-regenerate-button');
+    var sampleBtn = $('tryit-load-sample');
+    var postInput = $('tryit-post');
+    var bioInput = $('tryit-bio');
+    var toneInput = $('tryit-tone');
+
+    if (formSection) formSection.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+    if (generateBtn) generateBtn.disabled = disabled;
+    if (regenerateBtn) regenerateBtn.disabled = disabled;
+    if (sampleBtn) sampleBtn.disabled = disabled;
+    [postInput, bioInput, toneInput].forEach(function (el) {
+      if (el) el.disabled = disabled;
+    });
+  }
+
+  function scrollToResult() {
+    var result = $('tryit-demo-result');
+    if (result && !result.hidden) {
+      result.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  function persistLastResult(data) {
+    try {
+      sessionStorage.setItem(STORAGE.lastResult, JSON.stringify(data));
+    } catch (_e) {
+      /* quota / private browsing */
+    }
+  }
+
+  function restoreLastResult() {
+    try {
+      var raw = sessionStorage.getItem(STORAGE.lastResult);
+      if (!raw) return false;
+      showResult(JSON.parse(raw));
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  function showLockout(message, options) {
+    options = options || {};
     state.status = 'rate_limited';
     var formSection = $('try-it');
     var lockout = $('tryit-lockout');
     var lockoutMsg = $('tryit-lockout-message');
-    var generateBtn = $('tryit-demo-button');
-    var regenerateBtn = $('tryit-regenerate-button');
+    var result = $('tryit-demo-result');
+    var hasVisibleResult = result && !result.hidden;
 
-    if (formSection) formSection.hidden = true;
+    if (options.keepFormVisible) {
+      setFormDisabled(true);
+    } else if (formSection) {
+      formSection.hidden = true;
+      setFormDisabled(true);
+    } else {
+      setFormDisabled(true);
+    }
+
     if (lockout) lockout.hidden = false;
     if (lockoutMsg && message) lockoutMsg.textContent = message;
-    if (generateBtn) generateBtn.disabled = true;
-    if (regenerateBtn) regenerateBtn.disabled = true;
     updateSignupLinks();
+
+    if (options.scrollToResult && hasVisibleResult) {
+      requestAnimationFrame(function () {
+        requestAnimationFrame(scrollToResult);
+      });
+    }
   }
 
   function buildWhatHappenedSteps(data, isSampleOnly) {
@@ -395,6 +453,7 @@
 
     if (!isSampleOnly) {
       persistSignupContext();
+      persistLastResult(data);
     }
     updateSignupLinks();
 
@@ -429,7 +488,10 @@
 
   async function runGeneration(isRegenerate) {
     if (isLockedOut()) {
-      showLockout("You've seen how it works. Create your account to generate more comments.");
+      restoreLastResult();
+      showLockout("You've seen how it works. Create your account to generate more comments.", {
+        scrollToResult: true
+      });
       return;
     }
 
@@ -491,7 +553,10 @@
       }
 
       if (isLockedOut()) {
-        showLockout("You've seen how it works. Create your account to generate more comments.");
+        showLockout("You've seen how it works. Create your account to generate more comments.", {
+          keepFormVisible: true,
+          scrollToResult: true
+        });
       }
     } catch (err) {
       clearTimeout(timeoutId);
@@ -612,7 +677,10 @@
     updateSignupLinks();
 
     if (isLockedOut()) {
-      showLockout("You've seen how it works. Create your account to generate more comments.");
+      restoreLastResult();
+      showLockout("You've seen how it works. Create your account to generate more comments.", {
+        scrollToResult: true
+      });
     }
 
     var form = $('tryit-demo-form');

--- a/try-it.html
+++ b/try-it.html
@@ -58,10 +58,6 @@
                     <label for="tryit-post">LinkedIn hiring post</label>
                     <textarea id="tryit-post" class="rl-demo-textarea" rows="7" maxlength="3000" required placeholder="Paste a hiring post, e.g. We're hiring a data engineer… The demo personalizes job posts best."></textarea>
                     <p class="rl-demo-help tryit-char-count" id="tryit-post-count" aria-live="polite">0 / 3000 · min 20 characters</p>
-                    <div class="tryit-sample-row">
-                        <button type="button" class="tryit-sample-btn" id="tryit-load-sample-post">Try sample post</button>
-                        <button type="button" class="tryit-sample-btn tryit-sample-btn-pair" id="tryit-load-sample-pair">Try matched pair</button>
-                    </div>
                 </div>
 
                 <div class="rl-demo-field">
@@ -69,8 +65,9 @@
                     <textarea id="tryit-bio" class="rl-demo-textarea" rows="6" maxlength="2000" placeholder="e.g. I build data pipelines in Python and SQL, with 5 years in analytics engineering..."></textarea>
                     <p class="rl-demo-help tryit-char-count" id="tryit-bio-count" aria-live="polite">0 / 2000</p>
                     <p class="rl-demo-help tryit-bio-warn" id="tryit-bio-warn">Adding your background strongly improves personalization.</p>
-                    <button type="button" class="tryit-sample-btn" id="tryit-load-sample-bio">Try sample bio</button>
                 </div>
+
+                <button type="button" class="tryit-sample-btn" id="tryit-load-sample">Try a sample</button>
 
                 <div class="rl-demo-field">
                     <label for="tryit-tone">Tone</label>
@@ -91,7 +88,7 @@
                 <p class="tryit-loader" id="tryit-loader" hidden aria-live="polite">Understanding the post…</p>
 
                 <button type="submit" class="rl-button rl-generate-btn" id="tryit-demo-button">Generate comment</button>
-                <p class="rl-demo-help tryit-generate-hint">Tip: click sample buttons to cycle scenarios, or hit Generate with empty fields to auto-load the next matched pair.</p>
+                <p class="rl-demo-help tryit-generate-hint">No post handy? Try a sample, or hit Generate on empty fields to load the next one.</p>
                 <p class="rl-demo-help" id="tryit-attempts-help" aria-live="polite"></p>
                 <p class="rl-demo-error" id="tryit-demo-error" hidden></p>
             </form>


### PR DESCRIPTION
## Summary
- Replace three sample buttons with one **Try a sample** control that loads a matched hiring post + bio and cycles through 4 scenarios.
- Generate on empty fields still auto-loads the next sample.

## Test plan
- [ ] Click **Try a sample** — post and bio fill together, label advances
- [ ] Hit **Generate** on empty form — loads next sample and runs
- [ ] Paste your own post/bio — sample button does not interfere


Made with [Cursor](https://cursor.com)