### PR TITLE
Mitigate clickjacking on account-sensitive pages

### DIFF
--- a/README-SERVING.md
+++ b/README-SERVING.md
@@ -16,9 +16,12 @@ This is a **static website** - no build process required! Just serve the files d
 
 `serve.sh` writes `js/api-config.local.js` so the site calls your API on the port you pass (second argument). That file is removed when you stop the server.
 
-### Option 2: Python HTTP Server (Recommended)
+### Option 2: Python HTTP Server
 ```bash
-# Python 3
+# With security headers (same as ./serve.sh)
+python3 scripts/static_server.py 8000
+
+# Plain server (no extra headers)
 python3 -m http.server 8000
 
 # Python 2 (if Python 3 not available)
@@ -86,6 +89,27 @@ heyjunior-website/
 │   └── ...
 └── images/             # Images
 ```
+
+## Security headers (clickjacking)
+
+Production is on **GitHub Pages**, which does not let you set custom HTTP response headers from the repo. This project uses two layers:
+
+1. **`js/frame-guard.js`** on account-sensitive pages (login, checkout, register, password reset, partner dashboard). Loaded early in `<head>` so the page breaks out of hostile iframes.
+2. **`./serve.sh`** uses `scripts/static_server.py` locally so you get `X-Frame-Options` and `Content-Security-Policy: frame-ancestors 'self'` while developing.
+
+### Cloudflare (recommended for production)
+
+The site already uses Cloudflare (Web Analytics on checkout). In the Cloudflare dashboard for **heyjunior.ai**:
+
+1. **Rules** → **Transform Rules** → **Modify Response Header**
+2. Create a rule for hostname `heyjunior.ai` (and `www` if used)
+3. Set headers:
+   - `X-Frame-Options`: `SAMEORIGIN`
+   - `Content-Security-Policy`: `frame-ancestors 'self'`
+
+That is stronger than frame-busting JavaScript alone. Keep `frame-guard.js` as defense in depth.
+
+If you move to **Netlify** or **Cloudflare Pages**, the repo root `_headers` file applies the same headers automatically.
 
 ## Troubleshooting
 

--- a/_headers
+++ b/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  Content-Security-Policy: frame-ancestors 'self'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/checkout.html
+++ b/checkout.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="description" content="Get LinkedIn Automation Tool - Choose Your Plan">
     <title>Checkout - LinkedIn Automation Tool</title>
     <link rel="stylesheet" href="css/styles.css">

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="description" content="Reset your Junior account password">
     <title>Forgot Password - Junior</title>
     <link rel="stylesheet" href="css/styles.css">

--- a/js/frame-guard.js
+++ b/js/frame-guard.js
@@ -1,0 +1,17 @@
+/**
+ * Break out of embedding iframes (clickjacking mitigation).
+ * Prefer HTTP headers (X-Frame-Options / CSP frame-ancestors) when the host supports them.
+ */
+(function () {
+  'use strict';
+  if (window.self === window.top) {
+    return;
+  }
+  try {
+    window.top.location = window.self.location;
+  } catch (_) {
+    var style = document.createElement('style');
+    style.textContent = 'html,body{display:none!important}';
+    (document.documentElement || document.head).appendChild(style);
+  }
+})();

--- a/portal.html
+++ b/portal.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="description" content="Junior - User Portal Dashboard">
     <title>My Account - Junior</title>
     <link rel="stylesheet" href="css/styles.css">

--- a/register.html
+++ b/register.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="description" content="Get your first week free. Start getting interviews from conversations, not resumes.">
     <title>Get Started Free - Junior</title>
     <link rel="stylesheet" href="css/styles.css?v=20260425-register-personalized">

--- a/reseller-dashboard.html
+++ b/reseller-dashboard.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="robots" content="noindex">
     <title>Partner Dashboard - Junior</title>
     <link rel="stylesheet" href="css/styles.css">

--- a/reset-password/index.html
+++ b/reset-password/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="/js/frame-guard.js"></script>
     <meta name="description" content="Choose a new password for your Junior account">
     <title>Set New Password - Junior</title>
     <link rel="stylesheet" href="/css/styles.css">

--- a/scripts/static_server.py
+++ b/scripts/static_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Static file server with security headers (local dev)."""
+
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import sys
+
+
+class SecureStaticHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('X-Frame-Options', 'SAMEORIGIN')
+        self.send_header('Content-Security-Policy', "frame-ancestors 'self'")
+        self.send_header('X-Content-Type-Options', 'nosniff')
+        self.send_header('Referrer-Policy', 'strict-origin-when-cross-origin')
+        super().end_headers()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8002
+    server = ThreadingHTTPServer(('', port), SecureStaticHandler)
+    print(f'Serving with security headers on http://localhost:{port}')
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/serve.sh
+++ b/serve.sh
@@ -63,7 +63,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if command -v python3 &> /dev/null; then
-  python3 -m http.server "$SITE_PORT"
+  python3 scripts/static_server.py "$SITE_PORT"
 elif command -v python &> /dev/null; then
   python -m SimpleHTTPServer "$SITE_PORT"
 elif command -v npx &> /dev/null; then

--- a/success.html
+++ b/success.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="js/frame-guard.js"></script>
     <meta name="description" content="Thank you for your purchase - LinkedIn Automation Tool">
     <title>Success - LinkedIn Automation Tool</title>
     <link rel="stylesheet" href="css/styles.css">


### PR DESCRIPTION
## Summary
- Add `js/frame-guard.js` on login, checkout, register, password reset, partner dashboard, and success pages so they break out of hostile iframes (GitHub Pages cannot set framing headers from the repo).
- Serve `X-Frame-Options` and `Content-Security-Policy: frame-ancestors 'self'` in local dev via `scripts/static_server.py` (used by `./serve.sh`).
- Add root `_headers` for Netlify/Cloudflare Pages and document Cloudflare Transform Rules for production HTTP headers.

## Test plan
- [ ] Deploy preview or local: open `portal.html` inside a test iframe — page should break out or go blank, not remain usable in the frame.
- [ ] `./serve.sh` then `curl -sI http://localhost:8002/portal.html` — confirm `X-Frame-Options` and CSP `frame-ancestors` headers.
- [ ] Smoke-test login on `portal.html`, checkout, register, and forgot-password flows after merge.
- [ ] (Optional) Add Cloudflare response header transform rule per `README-SERVING.md` for defense in depth on heyjunior.ai.


Made with [Cursor](https://cursor.com)